### PR TITLE
fix: make columns of milestones adjust to content

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -247,13 +247,14 @@ hr {
 }
 
 .milestones ul {
+    width: 100%;
     padding: 0;
     margin: 0;
 }
 
 .milestones ul li{
     display: grid;
-    grid-template-columns: 30px auto;
+    grid-template-columns: minmax(30px,min-content) auto;
     padding: 0;
     font-size: 16px;
 }


### PR DESCRIPTION
Makes it so that the first column of the milestone always fits min content